### PR TITLE
chore: bump vendored minimatch override to patched 10.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9124,16 +9124,16 @@
     },
     "node_modules/minimatch10": {
       "name": "minimatch",
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.1.tgz",
-      "integrity": "sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==",
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.3.tgz",
+      "integrity": "sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -12149,10 +12149,10 @@
     },
     "vendor/minimatch-compat": {
       "name": "minimatch",
-      "version": "10.2.1",
+      "version": "10.2.3",
       "dev": true,
       "dependencies": {
-        "minimatch10": "npm:minimatch@10.2.1"
+        "minimatch10": "npm:minimatch@10.2.3"
       }
     }
   }

--- a/vendor/minimatch-compat/package.json
+++ b/vendor/minimatch-compat/package.json
@@ -1,10 +1,10 @@
 {
   "name": "minimatch",
-  "version": "10.2.1",
+  "version": "10.2.3",
   "private": true,
   "type": "commonjs",
   "main": "index.cjs",
   "dependencies": {
-    "minimatch10": "npm:minimatch@10.2.1"
+    "minimatch10": "npm:minimatch@10.2.3"
   }
 }


### PR DESCRIPTION
### Motivation
- Fix a reported ReDoS vulnerability in `minimatch` by updating the vendored compatibility package to the patched `10.2.3` release.

### Description
- Updated `vendor/minimatch-compat/package.json` to target `minimatch@10.2.3` and adjusted the compatibility alias to `minimatch10: "npm:minimatch@10.2.3"`.
- Regenerated `package-lock.json` so the `node_modules/minimatch10` entry and the `vendor/minimatch-compat` lock entry resolve to version `10.2.3` with the matching tarball and integrity fields.

### Testing
- Verified the lockfile contains `node_modules/minimatch10` at `10.2.3` with `node -e "const l=require('./package-lock.json'); if(l.packages['node_modules/minimatch10']?.version!=='10.2.3') process.exit(1); console.log('minimatch10',l.packages['node_modules/minimatch10'].version)"`, which succeeded.
- Ran `npm install --package-lock-only` to regenerate the lockfile, which completed; a full `npm install` failed with a `403` fetching the tarball due to registry access policy in the environment.
- Attempted `npm audit --omit=dev` but the npm advisory API is blocked in this environment and returned HTTP 403 so advisory checks could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acb7ac58508328b00dd1fb8f18a29e)