### PR TITLE
ci: update Node.js version to 20.9.x for Next.js build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.9.x
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
### Motivation
- The CI build was failing because Next.js requires Node.js `>=20.9.0` while the workflow used `18.x`, causing `npm run build` to exit with an error.

### Description
- Update `.github/workflows/ci.yml` to set `node-version: 20.9.x` in the `Setup Node` step so the CI runtime matches Next.js minimum requirements.

### Testing
- Ran `npm run build` locally with a compatible Node.js version and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acb9ef0e3883288bb177a5eebe0b55)